### PR TITLE
Simplify jsonapi_class configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,22 +6,35 @@ env:
   global:
     - CC_TEST_REPORTER_ID=98c9b3070ea9ac0e8f7afb6570f181506c3a06372b1db5c7deb8e46089fdf132
     - GIT_COMMITTED_AT=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then git log -1 --pretty=format:%ct; else git log -1 --skip 1 --pretty=format:%ct; fi)
+  matrix:
+    - RAILS_VERSION=5.0.0
+    - RAILS_VERSION=5.1.0
+    - RAILS_VERSION=5.2.0
+    - RAILS_VERSION=master
 rvm:
-  - 2.2.2
-  - 2.3.3
+  - 2.2.10
+  - 2.3.7
+  - 2.4.4
+  - 2.5.1
   - ruby-head
 matrix:
   allow_failures:
     - rvm: ruby-head
+    - env: RAILS_VERSION=master
+  exclude:
+    - rvm: 2.2.10
+      env: RAILS_VERSION=master
+    - rvm: 2.3.7
+      env: RAILS_VERSION=master
 before_script:
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
   - chmod +x ./cc-test-reporter
   - ./cc-test-reporter before-build
 after_script:
-  # Preferably you will run test-reporter on branch update events. But 
-  # if you setup travis to build PR updates only, you don't need to run 
+  # Preferably you will run test-reporter on branch update events. But
+  # if you setup travis to build PR updates only, you don't need to run
   # the line below
   - if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT; fi
-  # In the case where travis is setup to build PR updates only, 
+  # In the case where travis is setup to build PR updates only,
   # uncomment the line below
   # - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,15 @@
 source 'https://rubygems.org'
 
+rails_version = ENV['RAILS_VERSION'] || "default"
+rails = case rails_version
+        when 'master'
+          { github: 'rails/rails' }
+        when 'default'
+          '>= 5.0'
+        else
+          "~> #{ENV['RAILS_VERSION']}"
+        end
+
+gem 'rails', rails
+
 gemspec

--- a/lib/generators/jsonapi/initializer/templates/initializer.rb
+++ b/lib/generators/jsonapi/initializer/templates/initializer.rb
@@ -1,19 +1,31 @@
 JSONAPI::Rails.configure do |config|
-  # # Set a default serializable class mapping.
-  # config.jsonapi_class = Hash.new { |h, k|
-  #   names = k.to_s.split('::')
+  # # Set a default serializable class mapper
+  # # Can be a Proc or any object that responds to #call(class_name)
+  # #  e.g. MyCustomMapper.call('User::Article') => User::SerializableArticle
+  # config.jsonapi_class_mapper = -> (class_name) do
+  #   names = class_name.to_s.split('::')
   #   klass = names.pop
-  #   h[k] = [*names, "Serializable#{klass}"].join('::').safe_constantize
+  #   [*names, "Serializable#{klass}"].join('::').safe_constantize
+  # end
+  #
+  # # Set any default serializable class mappings
+  # config.jsonapi_class_mappings = {
+  #   :Car => SerializableVehicle,
+  #   :Boat => SerializableVehicle
   # }
   #
-  # # Set a default serializable class mapping for errors.
-  # config.jsonapi_errors_class = Hash.new { |h, k|
-  #   names = k.to_s.split('::')
-  #   klass = names.pop
-  #   h[k] = [*names, "Serializable#{klass}"].join('::').safe_constantize
-  # }.tap { |h|
-  #   h[:'ActiveModel::Errors'] = JSONAPI::Rails::SerializableActiveModelErrors
-  #   h[:Hash] = JSONAPI::Rails::SerializableErrorHash
+  # # Set a default serializable class mapper for errors.
+  # # Can be a Proc or any object that responds to #call(class_name)
+  # #  e.g. MyCustomMapper.call('PORO::Error') => PORO::SerializableError
+  # # If no jsonapi_errors_class_mapper is configured jsonapi_class_mapper will
+  # #  be used
+  # config.jsonapi_errors_class_mapper = config.jsonapi_class_mapper.dup
+  #
+  # # Set any default serializable class errors mappings
+  # config.jsonapi_errors_class_mappings = {
+  #   :'MyCustomModule::ErrorObject' => MyCustomModule::SerializableErrorObject,
+  #   :'ActiveModel::Errors' => JSONAPI::Rails::SerializableActiveModelErrors,
+  #   :Hash => JSONAPI::Rails::SerializableErrorHash
   # }
   #
   # # Set a default JSON API object.

--- a/lib/jsonapi/rails/configuration.rb
+++ b/lib/jsonapi/rails/configuration.rb
@@ -7,21 +7,20 @@ module JSONAPI
 
     # @private
     module Configurable
-      DEFAULT_JSONAPI_CLASS = Hash.new do |h, k|
-        names = k.to_s.split('::')
+      DEFAULT_JSONAPI_CLASS_MAPPER = -> (class_name) do
+        names = class_name.to_s.split('::')
         klass = names.pop
-        h[k] = [*names, "Serializable#{klass}"].join('::').safe_constantize
-      end.freeze
+        [*names, "Serializable#{klass}"].join('::').safe_constantize
+      end
 
-      DEFAULT_JSONAPI_ERRORS_CLASS = DEFAULT_JSONAPI_CLASS.dup.merge!(
-        'ActiveModel::Errors'.to_sym =>
-        JSONAPI::Rails::SerializableActiveModelErrors,
-        'Hash'.to_sym => JSONAPI::Rails::SerializableErrorHash
-      ).freeze
+      DEFAULT_JSONAPI_CLASS_MAPPINGS = {}.freeze
 
-      DEFAULT_JSONAPI_OBJECT = {
-        version: '1.0'
+      DEFAULT_JSONAPI_ERROR_CLASS_MAPPINGS = {
+        :'ActiveModel::Errors' => JSONAPI::Rails::SerializableActiveModelErrors,
+        :Hash => JSONAPI::Rails::SerializableErrorHash
       }.freeze
+
+      DEFAULT_JSONAPI_OBJECT = { version: '1.0' }.freeze
 
       DEFAULT_JSONAPI_CACHE = ->() { nil }
 
@@ -42,8 +41,10 @@ module JSONAPI
       DEFAULT_LOGGER = Logger.new(STDERR)
 
       DEFAULT_CONFIG = {
-        jsonapi_class: DEFAULT_JSONAPI_CLASS,
-        jsonapi_errors_class: DEFAULT_JSONAPI_ERRORS_CLASS,
+        jsonapi_class_mapper: DEFAULT_JSONAPI_CLASS_MAPPER,
+        jsonapi_class_mappings: DEFAULT_JSONAPI_CLASS_MAPPINGS,
+        jsonapi_errors_class_mapper: nil,
+        jsonapi_errors_class_mappings: DEFAULT_JSONAPI_ERROR_CLASS_MAPPINGS,
         jsonapi_cache:   DEFAULT_JSONAPI_CACHE,
         jsonapi_expose:  DEFAULT_JSONAPI_EXPOSE,
         jsonapi_fields:  DEFAULT_JSONAPI_FIELDS,

--- a/lib/jsonapi/rails/controller/hooks.rb
+++ b/lib/jsonapi/rails/controller/hooks.rb
@@ -1,4 +1,5 @@
 require 'jsonapi/rails/configuration'
+require 'jsonapi/rails/serializable_class_mapping'
 
 module JSONAPI
   module Rails
@@ -11,14 +12,21 @@ module JSONAPI
         # Overridden by the `class` renderer option.
         # @return [Hash{Symbol=>Class}]
         def jsonapi_class
-          JSONAPI::Rails.config[:jsonapi_class].dup
+          JSONAPI::Rails::SerializableClassMapping.new(
+            JSONAPI::Rails.config[:jsonapi_class_mapper],
+            JSONAPI::Rails.config[:jsonapi_class_mappings].dup
+          )
         end
 
         # Hook for serializable class mapping (for errors).
         # Overridden by the `class` renderer option.
         # @return [Hash{Symbol=>Class}]
         def jsonapi_errors_class
-          JSONAPI::Rails.config[:jsonapi_errors_class].dup
+          mapper = JSONAPI::Rails.config[:jsonapi_errors_class_mapper] ||
+            JSONAPI::Rails.config[:jsonapi_class_mapper]
+          JSONAPI::Rails::SerializableClassMapping.new(
+            mapper, JSONAPI::Rails.config[:jsonapi_errors_class_mappings].dup
+          )
         end
 
         # Hook for the jsonapi object.

--- a/lib/jsonapi/rails/serializable_class_mapping.rb
+++ b/lib/jsonapi/rails/serializable_class_mapping.rb
@@ -1,0 +1,13 @@
+module JSONAPI
+  module Rails
+    # @private
+    class SerializableClassMapping < Hash
+      def initialize(mapper, default_mappings = {})
+        super() do |hash, class_name_sym|
+          hash[class_name_sym] =
+            mapper.call(class_name_sym.to_s)
+        end.merge!(default_mappings)
+      end
+    end
+  end
+end

--- a/spec/dummy/config/initializers/new_framework_defaults.rb
+++ b/spec/dummy/config/initializers/new_framework_defaults.rb
@@ -18,7 +18,9 @@ ActiveSupport.to_time_preserves_timezone = true
 Rails.application.config.active_record.belongs_to_required_by_default = true
 
 # Do not halt callback chains when a callback returns false. Previous versions had true.
-ActiveSupport.halt_callback_chains_on_return_false = false
+if Rails.version.to_f < 5.2
+  ActiveSupport.halt_callback_chains_on_return_false = false
+end
 
 # Configure SSL options to enable HSTS with subdomains. Previous versions had false.
 Rails.application.config.ssl_options = { hsts: { subdomains: true } }


### PR DESCRIPTION
### Adds
• JSONAPI::Rails::SerializableClassMapping class
  Overriding Hash’s lookup can be confusing without creating an
  descendent class.
  - Old behavior
    inferrer.class == Hash
    Doesn’t make it obvious that there’s custom behavior
  - New behavior
    inferrer.class == JSONAPI::Rails::SerializableClassMapping
    Now it’s obvious where to look for the unusual behavior
  This setup also allows us to define the default mappings and the
  lookup behavior in separate configuration options
• configuration options for
  1. jsonapi_class_mapper
  2. jsonapi_class_mappings
  3. jsonapi_errors_class_mapper
    (fallback to jsonapi_class_mapper if nil)
  4. jsonapi_errors_class_mappings
### Removes
• configration options for
  1. jsonapi_class
  2. jsonapi_errors_class