### PR TITLE
Return source pointer '/data/attributes' if attribute was not supplied in payload

### DIFF
--- a/lib/jsonapi/rails/serializable_active_model_errors.rb
+++ b/lib/jsonapi/rails/serializable_active_model_errors.rb
@@ -11,7 +11,7 @@ module JSONAPI
       end
 
       source do
-        pointer @pointer unless @pointer.nil?
+        pointer(@pointer || '/data/attributes')
       end
     end
 


### PR DESCRIPTION
This PR fixes the source pointer when the payload is missing a validated attribute. 

e.g.

```ruby
class User
  validates :name, presence: true
end

class UsersController
  deserializable_resource :user

  def create
    user = User.new(user_params)
    if user.save
      render jsonapi: user
    else
      render jsonapi_errors: user.errors
    end 
  end

  private
  
  def user_params
    params.require(:user).permit(:name)
  end
end
```
if we post 
```json
{
  data: {
    attributes: {}
  }
}
```
We get back an error with an empty pointer
```json
{
  "errors": [
    {
      "title": "Invalid name",
      "detail": "Name can't be blank",
      "source": {}
    }
  ],
  "jsonapi": {
    "version": "1.0"
  }
}
```

With this change we return the node where the attribute is missing from

```json
{
  "errors": [
    {
      "title": "Invalid name",
      "detail": "Name can't be blank",
      "source": {
        "pointer": "/data/attributes"
      }
    }
  ],
  "jsonapi": {
    "version": "1.0"
  }
}
```