### PR TITLE
Render error when unable to deserialize resource

### DIFF
--- a/lib/generators/jsonapi/initializer/templates/initializer.rb
+++ b/lib/generators/jsonapi/initializer/templates/initializer.rb
@@ -69,6 +69,20 @@ JSONAPI::Rails.configure do |config|
   # # Set a default pagination scheme.
   # config.jsonapi_pagination = ->(_) { {} }
   #
+  # # Set the default action when the payload cannot be deserialized
+  # config.jsonapi_payload_malformed = -> {
+  #   render jsonapi_errors: {
+  #     title: 'Non-compliant Request Body',
+  #     detail: 'The request was not formatted in compliance with the application/vnd.api+json spec',
+  #     links: {
+  #       about: 'http://jsonapi.org/format/'
+  #     }
+  #   }, status: :bad_request
+  # }
+  #
+  # # Uncomment to take no action when the payload cannot be deserialized
+  # config.jsonapi_payload_malformed = nil
+  #
   # # Set a logger.
   # config.logger = Logger.new(STDOUT)
   #

--- a/lib/jsonapi/rails/configuration.rb
+++ b/lib/jsonapi/rails/configuration.rb
@@ -39,12 +39,22 @@ module JSONAPI
 
       DEFAULT_JSONAPI_PAGINATION = ->(_) { {} }
 
+      DEFAULT_JSONAPI_PAYLOAD_MALFORMED = -> {
+        render jsonapi_errors: {
+          title: 'Non-compliant Request Body',
+          detail: 'The request was not formatted in compliance with the application/vnd.api+json spec',
+          links: {
+            about: 'http://jsonapi.org/format/'
+          }
+        }, status: :bad_request
+      }
+
       DEFAULT_LOGGER = Logger.new(STDERR)
 
       DEFAULT_CONFIG = {
+        jsonapi_cache:   DEFAULT_JSONAPI_CACHE,
         jsonapi_class: DEFAULT_JSONAPI_CLASS,
         jsonapi_errors_class: DEFAULT_JSONAPI_ERRORS_CLASS,
-        jsonapi_cache:   DEFAULT_JSONAPI_CACHE,
         jsonapi_expose:  DEFAULT_JSONAPI_EXPOSE,
         jsonapi_fields:  DEFAULT_JSONAPI_FIELDS,
         jsonapi_include: DEFAULT_JSONAPI_INCLUDE,
@@ -52,6 +62,7 @@ module JSONAPI
         jsonapi_meta:    DEFAULT_JSONAPI_META,
         jsonapi_object:  DEFAULT_JSONAPI_OBJECT,
         jsonapi_pagination: DEFAULT_JSONAPI_PAGINATION,
+        jsonapi_payload_malformed: DEFAULT_JSONAPI_PAYLOAD_MALFORMED,
         logger: DEFAULT_LOGGER
       }.freeze
 

--- a/lib/jsonapi/rails/controller/deserialization.rb
+++ b/lib/jsonapi/rails/controller/deserialization.rb
@@ -55,6 +55,7 @@ module JSONAPI
                   "Unable to deserialize #{key} because no JSON API payload was" \
                   " found. (#{controller.controller_name}##{params[:action]})"
                 end
+                controller.jsonapi_payload_malformed
                 next
               end
 

--- a/lib/jsonapi/rails/controller/hooks.rb
+++ b/lib/jsonapi/rails/controller/hooks.rb
@@ -69,6 +69,12 @@ module JSONAPI
         def jsonapi_pagination(resources)
           instance_exec(resources, &JSONAPI::Rails.config[:jsonapi_pagination])
         end
+
+        # Hook for rendering jsonapi_errors when no payload passed
+        def jsonapi_payload_malformed
+          return unless JSONAPI::Rails.config[:jsonapi_payload_malformed]
+          instance_exec(&JSONAPI::Rails.config[:jsonapi_payload_malformed])
+        end
       end
     end
   end

--- a/spec/dummy/config/initializers/new_framework_defaults.rb
+++ b/spec/dummy/config/initializers/new_framework_defaults.rb
@@ -18,7 +18,9 @@ ActiveSupport.to_time_preserves_timezone = true
 Rails.application.config.active_record.belongs_to_required_by_default = true
 
 # Do not halt callback chains when a callback returns false. Previous versions had true.
-ActiveSupport.halt_callback_chains_on_return_false = false
+if Rails.version.to_f < 5.2
+  ActiveSupport.halt_callback_chains_on_return_false = false
+end
 
 # Configure SSL options to enable HSTS with subdomains. Previous versions had false.
 Rails.application.config.ssl_options = { hsts: { subdomains: true } }


### PR DESCRIPTION
Adds config option to set what happens when unable to deserialize payload
```ruby
  # config.jsonapi_payload_malformed = -> {
  #   render jsonapi_errors: {
  #     title: 'Non-compliant Request Body',
  #     detail: 'The request was not formatted in compliance with the application/vnd.api+json spec',
  #     links: {
  #       about: 'http://jsonapi.org/format/'
  #     }
  #   }, status: :bad_request
  # }
```
Able to override on controller by controller basis
Tested!